### PR TITLE
Dockerize SABIO server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 *.gz
 *.zip
 *.pkl
+
+# Include the vocabulary_presets json file
+!/docker/engines/vocabulary_presets.json

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.10
+
+# Create app user
+RUN useradd -m -U appuser
+
+# Install server in /app
+WORKDIR /app
+
+# Install python dependencies in /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Copy all other files
+COPY . .
+
+# Environment variables
+ENV LIMIT_REQUIRES_LINE=8190
+ENV LOG_LEVEL=critical
+ENV PORT=8080
+ENV SCRIPT_NAME=/api/v1/
+ENV TIMEOUT=600
+ENV WORKERS=2
+
+# Run as appuser
+USER appuser
+
+# Use start script to run the gunicorn server
+CMD ["./start.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,5 +28,5 @@ some notes:
  
 ## docker
 
-- build the container: `docker build . -t sabio-backend:1.0`
+- build the image: `docker build . -t sabio-backend:1.0`
 - run the container: `docker run -p 8080:8080 sabio-backend:1.0`

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,7 @@ some notes:
 
  - each spawned worker (e.g. by `gunicorn`) occupies the same amount of RAM, there is no sharing of resources (due to the Python GIL) 
  
- - 
- 
-    - 
+## docker
+
+- build the container: `docker build . -t sabio-backend:1.0`
+- run the container: `docker run -p 8080:8080 sabio-backend:1.0`

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.2
+flask-compress==1.13
 joblib==1.1.0
 numpy==1.25.2
 pandas==1.3.5

--- a/docker/src/app.py
+++ b/docker/src/app.py
@@ -10,11 +10,18 @@ import flask
 from flask import request
 from flask import jsonify as flask_jsonify
 from flask import Response
+from flask_compress import Compress
 
 # import numpy as np
 # import numpy.random as rand
 
 app = flask.Flask(__name__)
+
+# compress all server responses with gzip, deflate or brotli
+# for large responses this results in ±90% reduction (62.5MB -> 5.5MB) 
+# at a cost of ±15% response time (4.5s -> 5.2s)
+Compress(app)
+
 # !!! comment out for production !!!
 # app.config["DEBUG"] = True
 

--- a/docker/src/engines/VocabularyEnginev0.py
+++ b/docker/src/engines/VocabularyEnginev0.py
@@ -8,6 +8,7 @@ from engines.Engine import Engine, CachedEngine
 
 import re
 import json
+import os.path
 
 from collections import Counter
 
@@ -19,12 +20,14 @@ class VocabularyEngine(CachedEngine):
         self.max_score = 1.
         self.vocab_parser = re.compile("\s*,\s*")
         
-        # was src/engines/vocabulary_presets.json
-        with open("./engines/vocabulary_presets.json") as handle:
-            self.vocab_examples = json.load(handle)
-            self.all_examples = self.vocab2re(",".join(self.vocab_examples.values()))
-            self.vocab_examples = {list_name: self.vocab2re(word_list)
-                                   for list_name, word_list in self.vocab_examples.items()}
+         # load presets if the presets file exists
+        presets_file = "./engines/vocabulary_presets.json" 
+        if os.path.isfile(presets_file):
+            with open(presets_file) as handle:
+                self.vocab_examples = json.load(handle)
+                self.all_examples = self.vocab2re(",".join(self.vocab_examples.values()))
+                self.vocab_examples = {list_name: self.vocab2re(word_list)
+                                    for list_name, word_list in self.vocab_examples.items()}
 
         
     # assumes that `raw_vocab` is a string of comma-separated terms

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
-echo Starting Flask example app.
+echo "Starting Sabio Server"
 
+# Set missing environment variables to default values
+: "${LIMIT_REQUIRES_LINE:=8190}"
+: "${LOG_LEVEL:=critical}"
+: "${PORT:=8080}"
+: "${SCRIPT_NAME:=/api/v1/}"
+: "${TIMEOUT:=600}"
+: "${WORKERS:=2}"
+
+# Go to src directory
 cd ./src/
-# -w 1 implies that just 1 worker is spawned
-# timeout=600 required because some engines load large files on startup, which can take up to 5 minutes
-# see https://docs.gunicorn.org/en/stable/settings.html#limit-request-line -> put that here due to an error encountered once, in which case the request line was 7237
-SCRIPT_NAME=/api/v1/ gunicorn -w 2 -b 127.0.0.1:8080 'app:app' --log-level debug --timeout 600 --limit-request-line 8190
+
+# Start the server with the given parameters:
+# --limit-request-line https://docs.gunicorn.org/en/stable/settings.html#limit-request-line -> put that here due to an error encountered once, in which case the request line was 7237
+# --timeout 600 required because some engines load large files on startup, which can take up to 5 minutes
+# --workers 1 implies that just 1 worker is spawned
+gunicorn 'app:app' --bind 0.0.0.0:$PORT --limit-request-line $LIMIT_REQUIRES_LINE --log-level $LOG_LEVEL --timeout $TIMEOUT --workers $WORKERS 


### PR DESCRIPTION
This PR enables you to run the SABIO server in Docker. See the last section in `docker/README.md` how to build the image and run the container.

Additional improvements to make it run smoothly:
- A workaround for the missing file `docker/src/engines/vocabulary_presets.json` has been added. You might want to add this file to the repository.
- Output compression on all server responses, which leads to ±90% reduction for large responses (62.5MB -> 5.5MB)