### PR TITLE
Fix broken server

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,3 +8,4 @@ scipy==1.11.1
 swifter==1.3.2
 tqdm==4.62.3
 gunicorn==21.2.0
+Werkzeug==2.2.2


### PR DESCRIPTION
Lock Werkzeug version in requirements.txt

The new Werkzeug 3.0 did not work with Flask 2.0.2. Fix was to lock to version 2.2.2.

Fixes #7